### PR TITLE
chore: add CompileJsonValues to normalize values for JSON queries

### DIFF
--- a/grammar_test.go
+++ b/grammar_test.go
@@ -486,6 +486,46 @@ func (s *GrammarSuite) TestCompileJsonLength() {
 	}
 }
 
+func (s *GrammarSuite) TestCompileJsonValues() {
+	tests := []struct {
+		name     string
+		args     []any
+		expected []any
+	}{
+		{
+			name:     "number values",
+			args:     []any{1},
+			expected: []any{"1"},
+		},
+		{
+			name:     "number values",
+			args:     []any{[]int{1, 2, 3}},
+			expected: []any{[]any{"1", "2", "3"}},
+		},
+		{
+			name:     "string values",
+			args:     []any{"value1", "value2", "value3"},
+			expected: []any{"value1", "value2", "value3"},
+		},
+		{
+			name:     "boolean values",
+			args:     []any{true, false},
+			expected: []any{"true", "false"},
+		},
+		{
+			name:     "pointer values",
+			args:     []any{convert.Pointer(123)},
+			expected: []any{"123"},
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.Equal(tt.expected, s.grammar.CompileJsonValues(tt.args...))
+		})
+	}
+}
+
 func (s *GrammarSuite) TestCompilePrimary() {
 	mockBlueprint := mocksdriver.NewBlueprint(s.T())
 	mockBlueprint.EXPECT().GetTableName().Return("users").Once()


### PR DESCRIPTION
## 📑 Description

In JSON queries, certain database drivers (e.g., PostgreSQL) require numeric and boolean values to be passed as strings when used in JSON comparisons. Passing raw integers, floats, or booleans directly can result in encoding or type mismatch errors such as `unable to encode into text format for text (OID 25)`. This change introduces a normalization step to convert numeric and boolean values (including their pointer and slice variants) into string format for consistent behavior across different drivers.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
