### PR TITLE
fix: [#706] Setting timezone in MySQL DSN (e.g., Asia/Shanghai) causes “invalid DSN” error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ import (
         "username": config.Env("DB_USERNAME", ""),
         "password": config.Env("DB_PASSWORD", ""),
         "sslmode":  "disable",
-        "timezone": "UTC", // Asia/Shanghai
         "singular": false,
         "prefix":   "",
         "via": func() (driver.Driver, error) {

--- a/config.go
+++ b/config.go
@@ -62,7 +62,6 @@ func (r *Config) fillDefault(configs []contracts.Config) []contracts.FullConfig 
 			Prefix:      r.config.GetString(fmt.Sprintf("database.connections.%s.prefix", r.connection)),
 			Singular:    r.config.GetBool(fmt.Sprintf("database.connections.%s.singular", r.connection)),
 			Sslmode:     r.config.GetString(fmt.Sprintf("database.connections.%s.sslmode", r.connection)),
-			Timezone:    r.config.GetString(fmt.Sprintf("database.connections.%s.timezone", r.connection)),
 		}
 		if nameReplacer := r.config.Get(fmt.Sprintf("database.connections.%s.name_replacer", r.connection)); nameReplacer != nil {
 			if replacer, ok := nameReplacer.(contracts.Replacer); ok {
@@ -91,6 +90,13 @@ func (r *Config) fillDefault(configs []contracts.Config) []contracts.FullConfig 
 		}
 		if fullConfig.Database == "" {
 			fullConfig.Database = r.config.GetString(fmt.Sprintf("database.connections.%s.database", r.connection))
+		}
+		if fullConfig.Timezone == "" {
+			timezone := r.config.GetString(fmt.Sprintf("database.connections.%s.timezone", r.connection))
+			if timezone == "" {
+				timezone = r.config.GetString("app.timezone", "UTC")
+			}
+			fullConfig.Timezone = timezone
 		}
 		fullConfigs = append(fullConfigs, fullConfig)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -266,6 +266,50 @@ func (s *ConfigTestSuite) TestFillDefault() {
 				},
 			},
 		},
+		{
+			name: "success with app.timezone",
+			configs: []contracts.Config{
+				{
+					Dsn:      dsn,
+					Host:     host,
+					Port:     port,
+					Database: database,
+					Username: username,
+					Password: password,
+				},
+			},
+			setup: func() {
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.prefix", s.connection)).Return(prefix).Once()
+				s.mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.singular", s.connection)).Return(singular).Once()
+				s.mockConfig.EXPECT().GetBool(fmt.Sprintf("database.connections.%s.no_lower_case", s.connection)).Return(true).Once()
+				s.mockConfig.EXPECT().Get(fmt.Sprintf("database.connections.%s.name_replacer", s.connection)).Return(nameReplacer).Once()
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.sslmode", s.connection)).Return(sslmode).Once()
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.timezone", s.connection)).Return("").Once()
+				s.mockConfig.EXPECT().GetString("app.timezone", "UTC").Return(timezone).Once()
+				s.mockConfig.EXPECT().GetString(fmt.Sprintf("database.connections.%s.schema", s.connection), "public").Return(schema).Once()
+			},
+			expectConfigs: []contracts.FullConfig{
+				{
+					Connection:   s.connection,
+					Driver:       Name,
+					Prefix:       prefix,
+					Singular:     singular,
+					Sslmode:      sslmode,
+					Timezone:     timezone,
+					NoLowerCase:  true,
+					NameReplacer: nameReplacer,
+					Config: contracts.Config{
+						Dsn:      dsn,
+						Database: database,
+						Host:     host,
+						Port:     port,
+						Username: username,
+						Password: password,
+						Schema:   schema,
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/706

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refines the handling of timezones in the configuration logic by removing hardcoded defaults and introducing a fallback mechanism to use the application's timezone when a database connection-specific timezone is not provided. Additionally, it updates the corresponding tests to ensure this behavior is properly validated.

### Configuration Updates:
* Removed the hardcoded `"timezone": "UTC"` from the example configuration in `README.md`.
* Updated `fillDefault` in `config.go` to set the timezone dynamically. If no database connection-specific timezone is provided, it falls back to the application's timezone (`app.timezone`) with a default of `"UTC"`.

### Testing Enhancements:
* Added a new test case in `config_test.go` to verify the fallback mechanism for the timezone when `app.timezone` is used.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
