### PR TITLE
feat: add UUID and ULID type support in grammar

### DIFF
--- a/grammar.go
+++ b/grammar.go
@@ -777,6 +777,14 @@ func (r *Grammar) TypeTinyText(column driver.ColumnDefinition) string {
 	return "varchar(255)"
 }
 
+func (r *Grammar) TypeUuid(column driver.ColumnDefinition) string {
+	return "uuid"
+}
+
+func (r *Grammar) TypeUlid(column driver.ColumnDefinition) string {
+	return "char(26)"
+}
+
 func (r *Grammar) getColumns(blueprint driver.Blueprint) []string {
 	var columns []string
 	for _, column := range blueprint.GetAddedColumns() {

--- a/grammar.go
+++ b/grammar.go
@@ -781,10 +781,6 @@ func (r *Grammar) TypeUuid(column driver.ColumnDefinition) string {
 	return "uuid"
 }
 
-func (r *Grammar) TypeUlid(column driver.ColumnDefinition) string {
-	return "char(26)"
-}
-
 func (r *Grammar) getColumns(blueprint driver.Blueprint) []string {
 	var columns []string
 	for _, column := range blueprint.GetAddedColumns() {

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -1038,6 +1038,16 @@ func (s *GrammarSuite) TestTypeTimestampTz() {
 	s.Equal("timestamp(3) with time zone", s.grammar.TypeTimestampTz(mockColumn))
 }
 
+func (s *GrammarSuite) TestTypeUuid() {
+	mockColumn := mocksdriver.NewColumnDefinition(s.T())
+	s.Equal("uuid", s.grammar.TypeUuid(mockColumn))
+}
+
+func (s *GrammarSuite) TestTypeUlid() {
+	mockColumn := mocksdriver.NewColumnDefinition(s.T())
+	s.Equal("char(26)", s.grammar.TypeUlid(mockColumn))
+}
+
 func TestParseSchemaAndTable(t *testing.T) {
 	tests := []struct {
 		reference      string

--- a/grammar_test.go
+++ b/grammar_test.go
@@ -1043,11 +1043,6 @@ func (s *GrammarSuite) TestTypeUuid() {
 	s.Equal("uuid", s.grammar.TypeUuid(mockColumn))
 }
 
-func (s *GrammarSuite) TestTypeUlid() {
-	mockColumn := mocksdriver.NewColumnDefinition(s.T())
-	s.Equal("char(26)", s.grammar.TypeUlid(mockColumn))
-}
-
 func TestParseSchemaAndTable(t *testing.T) {
 	tests := []struct {
 		reference      string


### PR DESCRIPTION
## 📑 Description

Related: https://github.com/goravel/framework/pull/1114

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->
This pull request introduces support for two new database column types, `uuid` and `ulid`, in the `Grammar` class, along with corresponding unit tests to ensure their correctness.

### Added support for new column types:
* [`grammar.go`](diffhunk://#diff-077173eed4fe6bc9d3ea50005c9ad034d45bb24372cdc6aea57e61aab9f3afacR780-R787): Added methods `TypeUuid` and `TypeUlid` to the `Grammar` class to define the database column types `uuid` and `char(26)` respectively.

### Added unit tests for new column types:
* [`grammar_test.go`](diffhunk://#diff-8bec341f2415d1a975ac79feb01a945838efe972da6b9253a259af476c76608dR1041-R1050): Added test cases `TestTypeUuid` and `TestTypeUlid` in the `GrammarSuite` to verify the correct mapping of the `uuid` and `ulid` column types.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
