### PR TITLE
fix: [#768] Posgres DB ERROR: cached plan must not change result type

### DIFF
--- a/postgres.go
+++ b/postgres.go
@@ -98,5 +98,9 @@ func fullConfigToDialector(fullConfig contracts.FullConfig) gorm.Dialector {
 
 	return postgres.New(postgres.Config{
 		DSN: dsn,
+		// When running a migration to add or remove columns, the driver will panic with cached plan must not change result type.
+		// So PreferSimpleProtocol should be set to true to avoid this issue. The performance will down a little bit,
+		// but it's worth to provide a fully migration support.
+		PreferSimpleProtocol: true,
 	})
 }

--- a/postgres.go
+++ b/postgres.go
@@ -99,8 +99,8 @@ func fullConfigToDialector(fullConfig contracts.FullConfig) gorm.Dialector {
 	return postgres.New(postgres.Config{
 		DSN: dsn,
 		// When running a migration to add or remove columns, the driver will panic with cached plan must not change result type.
-		// So PreferSimpleProtocol should be set to true to avoid this issue. The performance will down a little bit,
-		// but it's worth to provide a fully migration support.
+		// So PreferSimpleProtocol should be set to true to avoid this issue. The performance will be reduced a little bit,
+		// but it's worth it to provide full migration support.
 		PreferSimpleProtocol: true,
 	})
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/768

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces a configuration change to the PostgreSQL driver to improve support for database migrations. The most important change is the addition of the `PreferSimpleProtocol: true` setting, which prevents errors during migrations at the cost of a slight performance decrease.

Database migration support:

* In the `fullConfigToDialector` function in `postgres.go`, set `PreferSimpleProtocol: true` in the PostgreSQL driver configuration to avoid "cached plan must not change result type" panics during schema migrations.

Before:

<img width="928" height="290" alt="image" src="https://github.com/user-attachments/assets/6aef0a48-12a2-46b1-a36d-c29288e2790d" />

<img width="1032" height="136" alt="image" src="https://github.com/user-attachments/assets/db5db818-91ee-43ba-a9df-7a18a7d09437" />

After: 

<img width="1478" height="992" alt="image" src="https://github.com/user-attachments/assets/88783eb3-b843-4611-be9b-b2ac5740d1ad" />

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
